### PR TITLE
docs: add test readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Encryption = new EncryptionOptions { Enabled = true, KeyBase64 = "<base64-32-byt
 ```
 Use `openssl rand -base64 32` to generate a key.
 
+## Tests
+- [Orleans job scheduler tests](tests/Orleans.Jobs.Tests/README.md)
+- [Orleans integration tests](tests/Orleans.Tests/README.md)
+- [Storage provider contract tests](tests/Storage.Tests/README.md)
+
 ## Notes
 - Additional providers (SQL, Azure Blob/Table, Cosmos) can be added by implementing `IDatabaseContext` and plugging into `StorageProviderFactory`.
 - The Kusto loader currently scans via `ListAsync`. Plug your Kusto-Loco engine where indicated to evaluate KQL.

--- a/tests/Orleans.Jobs.Tests/README.md
+++ b/tests/Orleans.Jobs.Tests/README.md
@@ -1,0 +1,13 @@
+# Orleans.Jobs.Tests
+
+These tests cover the Cloudbrick Orleans job system.
+
+## Scope
+- Validate job execution features such as cancellation, retries, and pause/resume behavior.
+- Uses an in-memory Orleans `TestCluster` with memory storage and streams.
+
+## Running the tests
+```bash
+dotnet test tests/Orleans.Jobs.Tests/Orleans.Jobs.Tests.csproj
+```
+No additional environment variables or external services are required.

--- a/tests/Orleans.Tests/README.md
+++ b/tests/Orleans.Tests/README.md
@@ -1,0 +1,13 @@
+# Orleans.Tests
+
+These tests exercise the DataExplorer Orleans integrations.
+
+## Scope
+- Validate grain storage mapping and reminder table functionality.
+- Uses the local FileSystem storage provider.
+
+## Running the tests
+```bash
+dotnet test tests/Orleans.Tests/Cloudbricks.Orleans.Tests.csproj
+```
+No additional environment variables or external services are required.

--- a/tests/Storage.Tests/README.md
+++ b/tests/Storage.Tests/README.md
@@ -1,0 +1,24 @@
+# Storage.Tests
+
+Contract tests for Cloudbrick DataExplorer storage providers.
+
+## Scope
+- Shared contract tests for CRUD, concurrency, and table lifecycle operations.
+- Targets multiple providers: FileSystem, Azure Blob, Azure Table, Cosmos DB, and SQL Server.
+
+## Running the tests
+```bash
+dotnet test tests/Storage.Tests/Cloudbrick.DataExplorer.Storage.Tests.csproj
+```
+
+### Provider-specific settings
+
+| Provider | Environment variables | External dependency |
+|----------|----------------------|---------------------|
+| Azure Blob | `TEST_BLOB_CONN` | Azurite emulator or Azure Storage account |
+| Azure Table | `TEST_TABLE_CONN` | Azurite emulator or Azure Storage account |
+| Cosmos DB | `TEST_COSMOS_ENDPOINT`, `TEST_COSMOS_KEY` | Azure Cosmos DB Emulator or account |
+| SQL Server | `TEST_SQL_CONN` | Accessible SQL Server database |
+| FileSystem | _None_ | Uses local temp directory |
+
+Tests for providers without the required environment variables are skipped.


### PR DESCRIPTION
## Summary
- document Orleans job tests
- document Orleans integration tests
- document storage provider test suite and required env vars
- link test documentation from repository root

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ee078603c8321b7a86eaf150c91ed