### PR TITLE
docs: add XML comments to storage abstractions

### DIFF
--- a/src/DataExplorer.Storage.Abstractions/Cloudbrick.DataExplorer.Storage.Abstractions.csproj
+++ b/src/DataExplorer.Storage.Abstractions/Cloudbrick.DataExplorer.Storage.Abstractions.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DataExplorer.Storage.Abstractions/IConfigAwareStorageManager.cs
+++ b/src/DataExplorer.Storage.Abstractions/IConfigAwareStorageManager.cs
@@ -4,12 +4,49 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Storage manager that is aware of database configuration and provider factories.
+/// </summary>
+/// <remarks>
+/// Extends <see cref="IStorageManager"/> by exposing configuration services and initialization routines.
+/// </remarks>
 public interface IConfigAwareStorageManager : IStorageManager
 {
+    /// <summary>
+    /// Gets the configuration manager for databases.
+    /// </summary>
     IDatabaseConfigManager Config { get; }
+
+    /// <summary>
+    /// Gets the factory responsible for creating storage providers.
+    /// </summary>
     IProviderFactory Providers { get; }
 
+    /// <summary>
+    /// Initializes the storage manager.
+    /// </summary>
+    /// <param name="createStructuresIfMissing">Indicates whether missing structures should be created.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Throws if initialization fails.
+    /// </remarks>
     Task InitializeAsync(bool createStructuresIfMissing = true, CancellationToken ct = default);
+
+    /// <summary>
+    /// Invalidates the cached provider for a database.
+    /// </summary>
+    /// <param name="databaseId">The database identifier.</param>
+    /// <remarks>
+    /// Subsequent calls to <see cref="IStorageManager.Database"/> will create a new provider for the database.
+    /// </remarks>
     void Invalidate(string databaseId);
+
+    /// <summary>
+    /// Invalidates all cached providers.
+    /// </summary>
+    /// <remarks>
+    /// Useful when global configuration changes occur.
+    /// </remarks>
     void InvalidateAll();
 }

--- a/src/DataExplorer.Storage.Abstractions/IContentEncryptor.cs
+++ b/src/DataExplorer.Storage.Abstractions/IContentEncryptor.cs
@@ -5,10 +5,47 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
+
+/// <summary>
+/// Performs encryption and decryption of content payloads.
+/// </summary>
+/// <remarks>
+/// Implementations may wrap cryptographic libraries. Errors during encryption or decryption should result in exceptions.
+/// </remarks>
 public interface IContentEncryptor
 {
+    /// <summary>
+    /// Gets a value indicating whether content is actually encrypted.
+    /// </summary>
+    /// <remarks>
+    /// If <c>false</c>, the encryptor acts as a pass-through.
+    /// </remarks>
     bool IsEncrypted { get; }
+
+    /// <summary>
+    /// Encrypts the specified plain text.
+    /// </summary>
+    /// <param name="plain">The plain text bytes.</param>
+    /// <param name="aad">Additional authenticated data that will not be encrypted.</param>
+    /// <param name="nonce">Outputs the generated nonce.</param>
+    /// <param name="tag">Outputs the authentication tag.</param>
+    /// <returns>The encrypted bytes.</returns>
+    /// <remarks>
+    /// Throws if encryption fails or the inputs are invalid.
+    /// </remarks>
     byte[] Encrypt(ReadOnlySpan<byte> plain, ReadOnlySpan<byte> aad, out byte[] nonce, out byte[] tag);
+
+    /// <summary>
+    /// Decrypts the provided cipher text.
+    /// </summary>
+    /// <param name="cipher">The encrypted bytes.</param>
+    /// <param name="aad">The associated data used during encryption.</param>
+    /// <param name="nonce">The nonce that was generated during encryption.</param>
+    /// <param name="tag">The authentication tag produced during encryption.</param>
+    /// <returns>The decrypted bytes.</returns>
+    /// <remarks>
+    /// Throws if authentication fails or the inputs are invalid.
+    /// </remarks>
     byte[] Decrypt(ReadOnlySpan<byte> cipher, ReadOnlySpan<byte> aad, ReadOnlySpan<byte> nonce, ReadOnlySpan<byte> tag);
 }
 public sealed class NoopEncryptor : IContentEncryptor

--- a/src/DataExplorer.Storage.Abstractions/IDatabaseConfigManager.cs
+++ b/src/DataExplorer.Storage.Abstractions/IDatabaseConfigManager.cs
@@ -5,10 +5,54 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Manages registration information for databases.
+/// </summary>
+/// <remarks>
+/// Implementations persist configuration and should validate inputs. Provider failures should result in exceptions.
+/// </remarks>
 public interface IDatabaseConfigManager
 {
+    /// <summary>
+    /// Adds a new registration or updates an existing one.
+    /// </summary>
+    /// <param name="config">The registration to persist.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Throws if <paramref name="config"/> is invalid or the operation fails.
+    /// </remarks>
     Task AddOrUpdateAsync(DatabaseRegistration config, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a registration for the specified database.
+    /// </summary>
+    /// <param name="databaseId">The database identifier.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns><c>true</c> if a registration was removed; otherwise <c>false</c>.</returns>
+    /// <remarks>
+    /// Throws if the remove operation fails.
+    /// </remarks>
     Task<bool> RemoveAsync(string databaseId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the registration for the specified database, if any.
+    /// </summary>
+    /// <param name="databaseId">The database identifier.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>The registration or <c>null</c> if none exists.</returns>
+    /// <remarks>
+    /// Throws if retrieval fails.
+    /// </remarks>
     Task<DatabaseRegistration?> GetAsync(string databaseId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists all database registrations.
+    /// </summary>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A read-only list of registrations.</returns>
+    /// <remarks>
+    /// Throws if listing fails.
+    /// </remarks>
     Task<IReadOnlyList<DatabaseRegistration>> ListAsync(CancellationToken ct = default);
 }

--- a/src/DataExplorer.Storage.Abstractions/IDatabaseContext.cs
+++ b/src/DataExplorer.Storage.Abstractions/IDatabaseContext.cs
@@ -4,14 +4,56 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Represents an operational context for a database.
+/// </summary>
+/// <remarks>
+/// Exposes administrative operations and access to table contexts.
+/// </remarks>
 public interface IDatabaseContext
 {
     // Admin
+
+    /// <summary>
+    /// Creates the database if it does not exist.
+    /// </summary>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Throws if the database cannot be created.
+    /// </remarks>
     Task CreateIfNotExistsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes the database if it exists.
+    /// </summary>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Throws if deletion fails.
+    /// </remarks>
     Task DeleteIfExistsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists the tables contained in the database.
+    /// </summary>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A read-only list of table information.</returns>
+    /// <remarks>
+    /// Throws if retrieval fails.
+    /// </remarks>
     Task<IReadOnlyList<TableInfo>> ListTablesAsync(CancellationToken ct = default);
 
     // Data
+
+    /// <summary>
+    /// Gets a context for the specified table.
+    /// </summary>
+    /// <param name="tableId">The table identifier.</param>
+    /// <returns>A table context for performing operations.</returns>
+    /// <remarks>
+    /// Throws if the table does not exist or cannot be accessed.
+    /// </remarks>
     ITableContext Table(string tableId);
-    
+
 }

--- a/src/DataExplorer.Storage.Abstractions/IExecutionContext.cs
+++ b/src/DataExplorer.Storage.Abstractions/IExecutionContext.cs
@@ -8,10 +8,31 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Describes contextual information for an execution flow.
+/// </summary>
+/// <remarks>
+/// Used for logging and telemetry to correlate operations.
+/// </remarks>
 public interface IExecutionContext
 {
+    /// <summary>
+    /// Gets the name of the action being executed.
+    /// </summary>
     string ActionName { get; }
+
+    /// <summary>
+    /// Gets a tracking identifier for correlation.
+    /// </summary>
     string TrackingId { get; }
+
+    /// <summary>
+    /// Gets the identifier of the acting principal.
+    /// </summary>
     string PrincipalId { get; }
+
+    /// <summary>
+    /// Gets the UTC timestamp when the action began.
+    /// </summary>
     DateTimeOffset StartedAtUtc { get; }
 }

--- a/src/DataExplorer.Storage.Abstractions/IExecutionContextAccessor.cs
+++ b/src/DataExplorer.Storage.Abstractions/IExecutionContextAccessor.cs
@@ -8,7 +8,19 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Provides access to the current <see cref="IExecutionContext"/>.
+/// </summary>
+/// <remarks>
+/// Implementations may store context in asynchronous local state. When no context is available, <c>null</c> is returned.
+/// </remarks>
 public interface IExecutionContextAccessor
 {
+    /// <summary>
+    /// Gets the current execution context if one has been established.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>null</c> when no execution context is present.
+    /// </remarks>
     IExecutionContext? Current { get; }
 }

--- a/src/DataExplorer.Storage.Abstractions/IExecutionScopeFactory.cs
+++ b/src/DataExplorer.Storage.Abstractions/IExecutionScopeFactory.cs
@@ -6,7 +6,22 @@ using Microsoft.Extensions.Logging;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Creates execution scopes used for logging and telemetry.
+/// </summary>
+/// <remarks>
+/// Scopes tie an <see cref="IExecutionContext"/> to log entries. Implementations should clean up resources when the scope is disposed.
+/// </remarks>
 public interface IExecutionScopeFactory
 {
+    /// <summary>
+    /// Begins a new execution scope.
+    /// </summary>
+    /// <param name="logger">The logger used to create the scope.</param>
+    /// <param name="ctx">The execution context for the scope.</param>
+    /// <returns>A disposable that ends the scope when disposed.</returns>
+    /// <remarks>
+    /// Throws if <paramref name="logger"/> or <paramref name="ctx"/> is <c>null</c>.
+    /// </remarks>
     IDisposable Begin(ILogger logger, IExecutionContext ctx);
 }

--- a/src/DataExplorer.Storage.Abstractions/IJsonDiffOptionsProvider.cs
+++ b/src/DataExplorer.Storage.Abstractions/IJsonDiffOptionsProvider.cs
@@ -2,7 +2,21 @@
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Provides access to <see cref="JsonDiffOptions"/> for individual databases.
+/// </summary>
+/// <remarks>
+/// Implementations may retrieve configuration from storage or compute defaults. An exception is thrown when no configuration is available.
+/// </remarks>
 public interface IJsonDiffOptionsProvider
 {
+    /// <summary>
+    /// Gets diff options for the specified database.
+    /// </summary>
+    /// <param name="databaseId">The identifier of the database.</param>
+    /// <returns>The diff options associated with the database.</returns>
+    /// <remarks>
+    /// Throws if <paramref name="databaseId"/> is unknown or configuration retrieval fails.
+    /// </remarks>
     JsonDiffOptions GetForDatabase(string databaseId);
 }

--- a/src/DataExplorer.Storage.Abstractions/IProviderFactory.cs
+++ b/src/DataExplorer.Storage.Abstractions/IProviderFactory.cs
@@ -8,7 +8,22 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Creates <see cref="IStorageProvider"/> instances based on configuration.
+/// </summary>
+/// <remarks>
+/// Implementations select the appropriate provider implementation for a database and options combination.
+/// </remarks>
 public interface IProviderFactory
 {
+    /// <summary>
+    /// Creates a storage provider for the specified database and options.
+    /// </summary>
+    /// <param name="databaseId">The database identifier.</param>
+    /// <param name="options">Provider configuration options.</param>
+    /// <returns>An initialized storage provider.</returns>
+    /// <remarks>
+    /// Throws if the provider cannot be created or the options are invalid.
+    /// </remarks>
     IStorageProvider Create(string databaseId, IProviderOptions options);
 }

--- a/src/DataExplorer.Storage.Abstractions/IProviderOptions.cs
+++ b/src/DataExplorer.Storage.Abstractions/IProviderOptions.cs
@@ -6,9 +6,27 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Defines configuration options for a storage provider.
+/// </summary>
+/// <remarks>
+/// Implementations expose provider-specific settings. Invalid values may lead to runtime failures when a provider is created.
+/// </remarks>
 public interface IProviderOptions
 {
+    /// <summary>
+    /// Gets the kind of storage provider that these options target.
+    /// </summary>
+    /// <remarks>
+    /// Implementations typically use this value to resolve the provider implementation. An unsupported value may result in an exception.
+    /// </remarks>
     StorageProviderKind Kind { get; }
-    /// <summary>Optional per-database diff settings; falls back to JsonDiff.Default if null.</summary>
+
+    /// <summary>
+    /// Optional per-database diff settings; falls back to <see cref="JsonDiffOptions.Default"/> if <c>null</c>.
+    /// </summary>
+    /// <remarks>
+    /// Returned options influence how document differences are calculated.
+    /// </remarks>
     JsonDiffOptions? Diff { get; }
 }

--- a/src/DataExplorer.Storage.Abstractions/IStorageManager.cs
+++ b/src/DataExplorer.Storage.Abstractions/IStorageManager.cs
@@ -4,7 +4,21 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Resolves <see cref="IDatabaseContext"/> instances by database identifier.
+/// </summary>
+/// <remarks>
+/// Implementations manage provider lifetimes and may cache contexts for efficiency.
+/// </remarks>
 public interface IStorageManager
 {
+    /// <summary>
+    /// Gets a context for interacting with the specified database.
+    /// </summary>
+    /// <param name="databaseId">The database identifier.</param>
+    /// <returns>A database context.</returns>
+    /// <remarks>
+    /// Throws if the database cannot be resolved or accessed.
+    /// </remarks>
     IDatabaseContext Database(string databaseId);
 }

--- a/src/DataExplorer.Storage.Abstractions/IStorageProvider.cs
+++ b/src/DataExplorer.Storage.Abstractions/IStorageProvider.cs
@@ -8,7 +8,21 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Resolves <see cref="IDatabaseContext"/> instances for a storage provider.
+/// </summary>
+/// <remarks>
+/// Providers encapsulate provider-specific logic. Implementations should validate database identifiers and surface provider errors.
+/// </remarks>
 public interface IStorageProvider
 {
+    /// <summary>
+    /// Gets a database context for the specified identifier.
+    /// </summary>
+    /// <param name="databaseId">The unique database identifier.</param>
+    /// <returns>A context used to interact with the database.</returns>
+    /// <remarks>
+    /// Throws if the database cannot be resolved or accessed.
+    /// </remarks>
     IDatabaseContext GetDatabase(string databaseId);
 }

--- a/src/DataExplorer.Storage.Abstractions/ITableContext.cs
+++ b/src/DataExplorer.Storage.Abstractions/ITableContext.cs
@@ -8,20 +8,114 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Provides CRUD and administrative operations for a storage table.
+/// </summary>
+/// <remarks>
+/// Implementations should honour cancellation requests and surface provider-specific failures via exceptions or <see cref="StorageResult{T}"/>.
+/// </remarks>
 public interface ITableContext
 {
     // Admin
+
+    /// <summary>
+    /// Creates the table if it does not already exist.
+    /// </summary>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Throws if the table cannot be created.
+    /// </remarks>
     Task CreateIfNotExistsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes the table if it exists.
+    /// </summary>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Throws if the deletion fails.
+    /// </remarks>
     Task DeleteIfExistsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Determines whether the table exists.
+    /// </summary>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns><c>true</c> if the table exists; otherwise <c>false</c>.</returns>
+    /// <remarks>
+    /// Throws if the existence check fails.
+    /// </remarks>
     Task<bool> ExistsAsync(CancellationToken ct = default);
 
     // CRUD
+
+    /// <summary>
+    /// Retrieves an item by identifier.
+    /// </summary>
+    /// <param name="id">The item identifier.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A storage result containing the item if found.</returns>
+    /// <remarks>
+    /// Returns a result indicating not found when the item does not exist; throws if retrieval fails.
+    /// </remarks>
     Task<StorageResult<StorageItem>> GetAsync(string id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists items in the table with optional paging.
+    /// </summary>
+    /// <param name="skip">The number of items to skip.</param>
+    /// <param name="take">The maximum number of items to return.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A storage result containing the retrieved items.</returns>
+    /// <remarks>
+    /// Throws if the list operation fails.
+    /// </remarks>
     Task<StorageResult<StorageItem>> ListAsync(int? skip = null, int? take = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Creates a new item in the table.
+    /// </summary>
+    /// <param name="id">The item identifier.</param>
+    /// <param name="entity">The item to create.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A storage result describing the created item.</returns>
+    /// <remarks>
+    /// Throws if an item with the same identifier already exists or creation fails.
+    /// </remarks>
     Task<StorageResult<StorageItem>> CreateAsync(string id, StorageItem entity, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates an existing item in the table.
+    /// </summary>
+    /// <param name="id">The item identifier.</param>
+    /// <param name="entity">The updated item.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A storage result describing the updated item.</returns>
+    /// <remarks>
+    /// Throws if the item does not exist or the update fails.
+    /// </remarks>
     Task<StorageResult<StorageItem>> UpdateAsync(string id, StorageItem entity, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes an item from the table.
+    /// </summary>
+    /// <param name="id">The item identifier.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>A storage result describing the deletion.</returns>
+    /// <remarks>
+    /// Returns a not found result when the item does not exist; throws if deletion fails.
+    /// </remarks>
     Task<StorageResult<StorageItem>> DeleteAsync(string id, CancellationToken ct = default);
 
     // Capabilities (query etc.)
+
+    /// <summary>
+    /// Gets the capabilities supported by the table.
+    /// </summary>
+    /// <returns>A value describing supported features such as querying.</returns>
+    /// <remarks>
+    /// Use the returned capabilities to determine which operations are available.
+    /// </remarks>
     TableCapabilities GetCapabilities();
 }

--- a/src/DataExplorer.Storage.Abstractions/ITableContextWithQuery.cs
+++ b/src/DataExplorer.Storage.Abstractions/ITableContextWithQuery.cs
@@ -4,4 +4,10 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Represents a table context that also supports querying.
+/// </summary>
+/// <remarks>
+/// Combines CRUD operations from <see cref="ITableContext"/> with query capabilities defined by <see cref="ITableQuery"/>.
+/// </remarks>
 public interface ITableContextWithQuery : ITableContext, ITableQuery { }

--- a/src/DataExplorer.Storage.Abstractions/ITableQuery.cs
+++ b/src/DataExplorer.Storage.Abstractions/ITableQuery.cs
@@ -4,8 +4,33 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Provides query capabilities for a table.
+/// </summary>
+/// <remarks>
+/// Implementations may support server-side filtering and pagination.
+/// </remarks>
 public interface ITableQuery
 {
+    /// <summary>
+    /// Executes a query and returns a single result set.
+    /// </summary>
+    /// <param name="spec">The query specification.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>The result of the query.</returns>
+    /// <remarks>
+    /// Throws if the query fails or <paramref name="spec"/> is invalid.
+    /// </remarks>
     Task<StorageQueryResult> QueryAsync(QuerySpec spec, CancellationToken ct = default);
+
+    /// <summary>
+    /// Executes a query and yields results page by page.
+    /// </summary>
+    /// <param name="spec">The query specification.</param>
+    /// <param name="ct">Token used to cancel the operation.</param>
+    /// <returns>An asynchronous sequence of query results.</returns>
+    /// <remarks>
+    /// Throws if the query fails or <paramref name="spec"/> is invalid.
+    /// </remarks>
     IAsyncEnumerable<StorageQueryResult> QueryPagesAsync(QuerySpec spec, CancellationToken ct = default);
 }

--- a/src/DataExplorer.Storage.Abstractions/IUserContext.cs
+++ b/src/DataExplorer.Storage.Abstractions/IUserContext.cs
@@ -8,9 +8,32 @@ using Cloudbrick.DataExplorer.Storage.Abstractions;
 
 namespace Cloudbrick.DataExplorer.Storage.Abstractions;
 
+/// <summary>
+/// Represents the identity of the user performing an operation.
+/// </summary>
+/// <remarks>
+/// Implementations expose principal information and optional claims for authorization and auditing.
+/// </remarks>
 public interface IUserContext
 {
+    /// <summary>
+    /// Gets the unique identifier of the principal.
+    /// </summary>
     string PrincipalId { get; }
+
+    /// <summary>
+    /// Gets the display name of the user, if available.
+    /// </summary>
+    /// <remarks>
+    /// May be <c>null</c> when the name is not known.
+    /// </remarks>
     string? Name { get; }
+
+    /// <summary>
+    /// Gets additional claims associated with the user.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>null</c> when no claims are provided.
+    /// </remarks>
     IReadOnlyDictionary<string, string>? Claims { get; }
 }


### PR DESCRIPTION
## Summary
- add XML documentation for storage abstractions interfaces
- enable XML documentation file generation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ee051a4ec8321a574663cd4dd8acb