### PR TITLE
Add README files for DataExplorer and Orleans projects

### DIFF
--- a/src/DataExplorer.Storage.Abstractions/README.md
+++ b/src/DataExplorer.Storage.Abstractions/README.md
@@ -1,0 +1,18 @@
+# DataExplorer.Storage.Abstractions
+
+## Purpose
+Defines the core contracts for the storage system including database, table and provider abstractions.
+
+## Public APIs
+- `IStorageManager` and `IConfigAwareStorageManager` for high-level data access.
+- `IDatabaseContext`, `ITableContext`, and `ITableQuery` for database and table operations.
+- `IStorageProvider` and `IProviderFactory` for pluggable storage backends.
+- Option and telemetry types such as `ProviderOptionsBase`, `StorageTelemetry`, and `RetryOptions`.
+
+## Build
+```bash
+dotnet build src/DataExplorer.Storage.Abstractions/Cloudbrick.DataExplorer.Storage.Abstractions.csproj
+```
+
+## Samples
+- [Storage.SampleApp](../../samples/Storage.SampleApp)

--- a/src/DataExplorer.Storage.Configuration/README.md
+++ b/src/DataExplorer.Storage.Configuration/README.md
@@ -1,0 +1,17 @@
+# DataExplorer.Storage.Configuration
+
+## Purpose
+Provides default implementations for configuring storage providers, managing database registrations, and supplying execution context and diff settings.
+
+## Public APIs
+- `ServiceCollectionExtensions.AddResourceManagerStorageCore` to register core services.
+- `ConfiguredStorageManager` and `InMemoryDatabaseConfigManager` for configuration-based access.
+- `IStorageProviderBuilder` implementations and helpers like `DefaultExecutionContextAccessor`.
+
+## Build
+```bash
+dotnet build src/DataExplorer.Storage.Configuration/Cloudbrick.DataExplorer.Storage.Configuration.csproj
+```
+
+## Samples
+- [Storage.SampleApp](../../samples/Storage.SampleApp)

--- a/src/DataExplorer.Storage.Provider.AzureBlob/README.md
+++ b/src/DataExplorer.Storage.Provider.AzureBlob/README.md
@@ -1,0 +1,17 @@
+# DataExplorer.Storage.Provider.AzureBlob
+
+## Purpose
+Implements a storage provider backed by Azure Blob Storage.
+
+## Public APIs
+- `BlobStorageProvider` and `BlobDatabaseContext` for blob-based tables.
+- `BlobOptions` to configure connection and sharding.
+- `AzureBlobProviderBuilder` and `RegistrationExtensions.AddAzureBlobDatabase` for DI registration.
+
+## Build
+```bash
+dotnet build src/DataExplorer.Storage.Provider.AzureBlob/Cloudbrick.DataExplorer.Storage.Provider.AzureBlob.csproj
+```
+
+## Samples
+- [Storage.SampleApp](../../samples/Storage.SampleApp)

--- a/src/DataExplorer.Storage.Provider.AzureTable/README.md
+++ b/src/DataExplorer.Storage.Provider.AzureTable/README.md
@@ -1,0 +1,17 @@
+# DataExplorer.Storage.Provider.AzureTable
+
+## Purpose
+Provides an Azure Table Storage backed implementation of the storage provider interfaces.
+
+## Public APIs
+- `TableStorageProvider` and `TableDatabaseContext` for table storage access.
+- `TableOptions` to set connection details and naming behavior.
+- `AzureTableProviderBuilder` and `RegistrationExtensions.AddAzureTableDatabase` for DI wiring.
+
+## Build
+```bash
+dotnet build src/DataExplorer.Storage.Provider.AzureTable/Cloudbrick.DataExplorer.Storage.Provider.AzureTable.csproj
+```
+
+## Samples
+- [Storage.SampleApp](../../samples/Storage.SampleApp)

--- a/src/DataExplorer.Storage.Provider.Cosmos/README.md
+++ b/src/DataExplorer.Storage.Provider.Cosmos/README.md
@@ -1,0 +1,17 @@
+# DataExplorer.Storage.Provider.Cosmos
+
+## Purpose
+Adds a provider implementation backed by Azure Cosmos DB.
+
+## Public APIs
+- `CosmosStorageProvider` and `CosmosDatabaseContext` for Cosmos containers.
+- `CosmosOptions` to configure endpoint, key, and partitioning.
+- `CosmosProviderBuilder` and `RegistrationExtensions.AddAzureCosmosDatabase` for dependency injection.
+
+## Build
+```bash
+dotnet build src/DataExplorer.Storage.Provider.Cosmos/Cloudbrick.DataExplorer.Storage.Provider.Cosmos.csproj
+```
+
+## Samples
+- [Storage.SampleApp](../../samples/Storage.SampleApp)

--- a/src/DataExplorer.Storage.Provider.FileSystem/README.md
+++ b/src/DataExplorer.Storage.Provider.FileSystem/README.md
@@ -1,0 +1,17 @@
+# DataExplorer.Storage.Provider.FileSystem
+
+## Purpose
+Provides a file system based storage provider with optional AES-GCM encryption and sharded file layout.
+
+## Public APIs
+- `FileSystemStorageProvider` and `FileSystemDatabaseContext` for local disk storage.
+- `FileSystemOptions` and `EncryptionOptions` to configure paths and at-rest encryption.
+- `FileSystemProviderBuilder` and `RegistrationExtensions.AddLocalFileSystemDatabase` for DI registration.
+
+## Build
+```bash
+dotnet build src/DataExplorer.Storage.Provider.FileSystem/Cloudbrick.DataExplorer.Storage.Provider.FileSystem.csproj
+```
+
+## Samples
+- [Storage.SampleApp](../../samples/Storage.SampleApp)

--- a/src/DataExplorer.Storage.Provider.Sql/README.md
+++ b/src/DataExplorer.Storage.Provider.Sql/README.md
@@ -1,0 +1,17 @@
+# DataExplorer.Storage.Provider.Sql
+
+## Purpose
+Implements a SQL-based storage provider using relational tables and schemas.
+
+## Public APIs
+- `SqlStorageProvider` and `SqlDatabaseContext` for SQL database operations.
+- `SqlOptions` to supply connection strings and schema names.
+- `SqlProviderBuilder` and `RegistrationExtensions.AddSqlDatabase` for dependency injection.
+
+## Build
+```bash
+dotnet build src/DataExplorer.Storage.Provider.Sql/Cloudbrick.DataExplorer.Storage.Provider.Sql.csproj
+```
+
+## Samples
+- [Storage.SampleApp](../../samples/Storage.SampleApp)

--- a/src/DataExplorer.Storage/README.md
+++ b/src/DataExplorer.Storage/README.md
@@ -1,0 +1,16 @@
+# DataExplorer.Storage
+
+## Purpose
+Provides dependency injection extensions to configure DataExplorer storage and register a single backing provider.
+
+## Public APIs
+- `IResourceManagerServiceContext` for registering providers.
+- `ServiceCollectionExtensions.AddResourceManagerStorage` to add core services and obtain a configuration context.
+
+## Build
+```bash
+dotnet build src/DataExplorer.Storage/Cloudbrick.DataExplorer.Storage.csproj
+```
+
+## Samples
+- [Storage.SampleApp](../../samples/Storage.SampleApp)

--- a/src/Orleans.Abstractions/README.md
+++ b/src/Orleans.Abstractions/README.md
@@ -1,0 +1,16 @@
+# Orleans.Abstractions
+
+## Purpose
+Contains helper types for Orleans integrations including JSON-based grain key formatting utilities.
+
+## Public APIs
+- `CompoundJsonKey`, `GrainKeyJsonHelper`, and `JsonKeyFormat` for building grain identifiers.
+- `OrleansJsonKeyExtensions` with extensions for parsing and composing keys.
+
+## Build
+```bash
+dotnet build src/Orleans.Abstractions/Cloudbrick.Orleans.Abstractions.csproj
+```
+
+## Samples
+See [Orleans.Jobs.Playground](../../samples/Orleans.Jobs.Playground) for usage in a grain-based application.

--- a/src/Orleans.Jobs.Abstractions/README.md
+++ b/src/Orleans.Jobs.Abstractions/README.md
@@ -1,0 +1,18 @@
+# Orleans.Jobs.Abstractions
+
+## Purpose
+Defines the contracts and data models for distributed job scheduling and execution in Orleans.
+
+## Public APIs
+- Grain interfaces such as `IJobGrain`, `ITaskGrain`, `IJobsManagerGrain`, and `IScheduledJobsManagerGrain`.
+- Manager interfaces `IJobsManager` and `IScheduledJobsManager`.
+- Models including `JobSpec`, `TaskSpec`, `JobState`, `ExecutionEvent`, and related enums.
+
+## Build
+```bash
+dotnet build src/Orleans.Jobs.Abstractions/Cloudbrick.Orleans.Jobs.Abstractions.csproj
+```
+
+## Samples
+- [Orleans.Jobs.Playground](../../samples/Orleans.Jobs.Playground)
+- [Components.Sample](../../samples/Components.Sample)

--- a/src/Orleans.Jobs.Grains/README.md
+++ b/src/Orleans.Jobs.Grains/README.md
@@ -1,0 +1,18 @@
+# Orleans.Jobs.Grains
+
+## Purpose
+Provides grain implementations and supporting infrastructure for running distributed jobs and tasks with Orleans.
+
+## Public APIs
+- Grain types such as `JobGrain`, `TaskGrain`, `JobsManagerGrain`, and scheduled job grains.
+- `JobsSiloBuilderExtensions` to register job services with an Orleans silo.
+- Executor and telemetry components including `ITaskExecutor` implementations and `TelemetryHub`.
+
+## Build
+```bash
+dotnet build src/Orleans.Jobs.Grains/Cloudbrick.Orleans.Jobs.csproj
+```
+
+## Samples
+- [Orleans.Jobs.Playground](../../samples/Orleans.Jobs.Playground)
+- [Components.Sample](../../samples/Components.Sample)

--- a/src/Orleans.Persistance.DataExplorer/README.md
+++ b/src/Orleans.Persistance.DataExplorer/README.md
@@ -1,0 +1,17 @@
+# Orleans.Persistance.DataExplorer
+
+## Purpose
+Implements an Orleans grain storage provider using the DataExplorer storage abstractions.
+
+## Public APIs
+- `DataExplorerGrainStorage` implementing Orleans `IGrainStorage`.
+- `DataExplorerOrleansStorageOptions` for configuring database and table names.
+- `SiloBuilderExtensions.AddDataExplorerGrainStorage` to register the provider with a silo.
+
+## Build
+```bash
+dotnet build src/Orleans.Persistance.DataExplorer/Cloudbrick.Orleans.Persistance.DataExplorer.csproj
+```
+
+## Samples
+No dedicated sample is provided.

--- a/src/Orleans.Reminders.DataExplorer/README.md
+++ b/src/Orleans.Reminders.DataExplorer/README.md
@@ -1,0 +1,17 @@
+# Orleans.Reminders.DataExplorer
+
+## Purpose
+Provides an Orleans reminders table implementation backed by DataExplorer storage.
+
+## Public APIs
+- `DataExplorerReminderTable` storing reminder state.
+- `DataExplorerReminderOptions` to configure database and table identifiers.
+- `SiloBuilderExtensions.AddDataExplorerReminders` to register the reminder service.
+
+## Build
+```bash
+dotnet build src/Orleans.Reminders.DataExplorer/Cloudbrick.Orleans.Reminders.DataExplorer.csproj
+```
+
+## Samples
+No dedicated sample is available.

--- a/src/Orleans.SignalR/README.md
+++ b/src/Orleans.SignalR/README.md
@@ -1,0 +1,17 @@
+# Orleans.SignalR
+
+## Purpose
+Integrates SignalR with Orleans so hub messages can be routed through grains.
+
+## Public APIs
+- `SiloExtensions.AddCloudbrickSignalR` and `MapCloudbrickSignalR` for configuring hubs.
+- Grain types such as `HubGrain`, `HubPublisherGrain`, and `HubDirectoryGrain`.
+- `DynamicHub` and helpers like `HubRelayHostedService` and `HubMessageSender`.
+
+## Build
+```bash
+dotnet build src/Orleans.SignalR/Cloudbrick.Orleans.SignalR.csproj
+```
+
+## Samples
+- [Components.Sample](../../samples/Components.Sample)

--- a/src/Orleans/README.md
+++ b/src/Orleans/README.md
@@ -1,0 +1,15 @@
+# Orleans
+
+## Purpose
+Aggregates Cloudbrick Orleans integrations such as jobs, persistence, reminders, and SignalR into a single package reference.
+
+## Public APIs
+This project exposes no additional types; it simply references other Cloudbrick Orleans packages.
+
+## Build
+```bash
+dotnet build src/Orleans/Cloudbrick.Orleans.csproj
+```
+
+## Samples
+Refer to individual package samples like [Components.Sample](../../samples/Components.Sample) or [Orleans.Jobs.Playground](../../samples/Orleans.Jobs.Playground).


### PR DESCRIPTION
## Summary
- Document DataExplorer storage projects with purpose, key APIs, build commands, and sample links
- Add README coverage for Orleans integrations including jobs, persistence, reminders, and SignalR

## Testing
- `dotnet build Cloudbrick.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ee04eb3288321b2809f6b068c3cc2