### PR TITLE
Expand README overview for Cloudbrick and update names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,35 @@
-# ResourceManager.Storage (Out-of-the-box)
+# Cloudbrick (Out-of-the-box)
 
-This solution builds and runs **without external NuGet dependencies** beyond .NET 8:
+This solution builds and runs **without external NuGet dependencies** beyond .NET 8.
 
-- `ResourceManager.Storage.Abstractions` — core types, telemetry scaffold, retry, JSON diff.
-- `ResourceManager.Storage.Configuration` — DB registration, provider factory, config-aware manager, DI.
-- `ResourceManager.Storage.Provider.FileSystem` — local FileSystem provider with sharded SHA-256 file names, ETag, optional AES-GCM encryption.
-- `ResourceManager.Storage.KustoLoco` — simple table loader stub to stream/list data (placeholder for real Kusto-Loco eval).
-- `ResourceManager.SampleApp` — console app showing end-to-end usage.
+## Components
+- `Cloudbrick.Components.Blades` — Azure-Portal style blade controls for Blazor.
+- `Cloudbrick.Components.Jobs` — Fluent UI components for viewing and controlling jobs with live telemetry.
+
+## DataExplorer storage
+- `Cloudbrick.DataExplorer.Storage.Abstractions` — core types, telemetry scaffold, retry, JSON diff.
+- `Cloudbrick.DataExplorer.Storage.Configuration` — DB registration, provider factory, config-aware manager, DI.
+- `Cloudbrick.DataExplorer.Storage` — service context helpers.
+- Providers:
+  - `Cloudbrick.DataExplorer.Storage.Provider.FileSystem` — local FileSystem provider with sharded SHA-256 file names, ETag, optional AES-GCM encryption.
+  - `Cloudbrick.DataExplorer.Storage.Provider.Sql` — SQL-based provider.
+  - `Cloudbrick.DataExplorer.Storage.Provider.AzureBlob` — Azure Blob provider.
+  - `Cloudbrick.DataExplorer.Storage.Provider.AzureTable` — Azure Table provider.
+  - `Cloudbrick.DataExplorer.Storage.Provider.Cosmos` — Cosmos DB provider.
+- `Cloudbrick.DataExplorer.Storage.SampleApp` — console app showing end-to-end usage.
+
+## Orleans
+- `Cloudbrick.Orleans.Abstractions` — shared contracts for Orleans integration.
+- `Cloudbrick.Orleans` — Orleans hosting helpers.
+- `Cloudbrick.Orleans.Persistance.DataExplorer` — DataExplorer-backed storage for Orleans grains.
+- `Cloudbrick.Orleans.Reminders.DataExplorer` — DataExplorer-backed reminder provider.
+- `Cloudbrick.Orleans.SignalR` — SignalR integration.
+- `Cloudbrick.Orleans.Jobs.Abstractions` and `Cloudbrick.Orleans.Jobs` — job grain contracts and implementations.
 
 ## Run
 ```bash
-dotnet build ResourceManager.Storage.sln
-dotnet run --project samples/ResourceManager.SampleApp/ResourceManager.SampleApp.csproj
+dotnet build Cloudbrick.sln
+dotnet run --project samples/Storage.SampleApp/Cloudbrick.DataExplorer.Storage.SampleApp.csproj
 ```
 This will create a `data/` folder under the app base directory and demonstrate create/get/update/list/query/delete.
 


### PR DESCRIPTION
## Summary
- Rename ResourceManager references to Cloudbrick
- Expand README overview for Components, DataExplorer storage providers, and Orleans projects
- Update run instructions to use Cloudbrick.sln and storage sample app

## Testing
- `dotnet build Cloudbrick.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ee044ac088321b7e1a2a7630be368