### PR TITLE
feat: chainable scheduled jobs manager

### DIFF
--- a/src/Orleans.Jobs.Abstractions/Managers/IScheduledJobsManager.cs
+++ b/src/Orleans.Jobs.Abstractions/Managers/IScheduledJobsManager.cs
@@ -2,17 +2,43 @@ using Cloudbrick.Orleans.Jobs.Abstractions.Models;
 
 namespace Cloudbrick.Orleans.Jobs.Abstractions.Managers
 {
+    /// <summary>
+    /// Manager for creating and controlling scheduled jobs. All mutating
+    /// operations return the manager instance to allow fluent chaining.
+    /// </summary>
     public interface IScheduledJobsManager
     {
-        Task<string> CreateAsync(ScheduledJobSpec spec);
-        Task DeleteAsync(string id);
-        Task DisableAsync(string id);
-        Task EnableAsync(string id);
+        /// <summary>
+        /// Creates a new scheduled job and returns the manager for chaining along
+        /// with the generated identifier.
+        /// </summary>
+        Task<(IScheduledJobsManager Manager, string Id)> CreateAsync(ScheduledJobSpec spec);
+
+        /// <summary>Deletes the specified scheduled job.</summary>
+        Task<IScheduledJobsManager> DeleteAsync(string id);
+
+        /// <summary>Disables the specified scheduled job.</summary>
+        Task<IScheduledJobsManager> DisableAsync(string id);
+
+        /// <summary>Enables the specified scheduled job.</summary>
+        Task<IScheduledJobsManager> EnableAsync(string id);
+
+        /// <summary>Gets the current state of the scheduled job.</summary>
         Task<ScheduledJobState?> GetAsync(string id);
+
+        /// <summary>Lists all known scheduled job identifiers.</summary>
         Task<List<string>> ListAsync();
-        Task PauseAsync(string id);
-        Task ResumeAsync(string id);
-        Task RunNowAsync(string id);
-        Task UpdateAsync(string id, ScheduledJobSpec spec);
+
+        /// <summary>Pauses the specified scheduled job.</summary>
+        Task<IScheduledJobsManager> PauseAsync(string id);
+
+        /// <summary>Resumes a previously paused scheduled job.</summary>
+        Task<IScheduledJobsManager> ResumeAsync(string id);
+
+        /// <summary>Runs the scheduled job immediately.</summary>
+        Task<IScheduledJobsManager> RunNowAsync(string id);
+
+        /// <summary>Updates an existing scheduled job.</summary>
+        Task<IScheduledJobsManager> UpdateAsync(string id, ScheduledJobSpec spec);
     }
 }

--- a/src/Orleans.Jobs.Grains/Managers/ScheduledJobsManager.cs
+++ b/src/Orleans.Jobs.Grains/Managers/ScheduledJobsManager.cs
@@ -39,34 +39,56 @@ namespace Cloudbrick.Orleans.Jobs.Managers
         }
 
 
-        public virtual async Task<string> CreateAsync(ScheduledJobSpec spec)
+        public virtual async Task<(IScheduledJobsManager Manager, string Id)> CreateAsync(ScheduledJobSpec spec)
         {
             var mgr = _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler");
             var id = await mgr.CreateAsync(spec);
-            return id;
+            return (this, id);
         }
 
-        public virtual async Task UpdateAsync(string id, ScheduledJobSpec spec)
+        public virtual async Task<IScheduledJobsManager> UpdateAsync(string id, ScheduledJobSpec spec)
         {
             spec.TemplateId = id;
             var mgr = _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler");
             await mgr.UpdateAsync(spec);
+            return this;
         }
 
-        public virtual async Task DeleteAsync(string id)
+        public virtual async Task<IScheduledJobsManager> DeleteAsync(string id)
         {
             var mgr = _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler");
             await mgr.DeleteAsync(id);
+            return this;
         }
 
-        public virtual Task EnableAsync(string id) => _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").EnableAsync(id);
+        public virtual async Task<IScheduledJobsManager> EnableAsync(string id)
+        {
+            await _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").EnableAsync(id);
+            return this;
+        }
 
-        public virtual Task DisableAsync(string id) => _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").DisableAsync(id);
+        public virtual async Task<IScheduledJobsManager> DisableAsync(string id)
+        {
+            await _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").DisableAsync(id);
+            return this;
+        }
 
-        public virtual Task PauseAsync(string id) => _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").PauseAsync(id);
+        public virtual async Task<IScheduledJobsManager> PauseAsync(string id)
+        {
+            await _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").PauseAsync(id);
+            return this;
+        }
 
-        public virtual Task ResumeAsync(string id) => _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").ResumeAsync(id);
+        public virtual async Task<IScheduledJobsManager> ResumeAsync(string id)
+        {
+            await _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").ResumeAsync(id);
+            return this;
+        }
 
-        public virtual Task RunNowAsync(string id) => _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").RunNowAsync(id);
+        public virtual async Task<IScheduledJobsManager> RunNowAsync(string id)
+        {
+            await _orleans.GetGrain<IScheduledJobsManagerGrain>("scheduler").RunNowAsync(id);
+            return this;
+        }
     }
 }

--- a/tests/Orleans.Jobs.Tests/FluentScheduledJobsTests.cs
+++ b/tests/Orleans.Jobs.Tests/FluentScheduledJobsTests.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using Cloudbrick.Orleans.Jobs.Abstractions.Managers;
+using Cloudbrick.Orleans.Jobs.Abstractions.Models;
+using Cloudbrick.Orleans.Jobs.Managers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Orleans.Jobs.Tests;
+
+public class FluentScheduledJobsTests : IClassFixture<ClusterFixture>
+{
+    private readonly ClusterFixture _fx;
+    public FluentScheduledJobsTests(ClusterFixture fx) => _fx = fx;
+
+    [Fact]
+    public async Task ManagerSupportsFluentChaining()
+    {
+        var manager = new ScheduledJobsManager(_fx.Cluster.Client, NullLogger<ScheduledJobsManager>.Instance);
+        var spec = new ScheduledJobSpec
+        {
+            Job = new JobSpec()
+        };
+        spec.Job.Tasks["t1"] = new TaskSpec { ExecutorType = "delay", CommandJson = "{ \"milliseconds\": 1 }" };
+
+        var creation = await manager.CreateAsync(spec);
+
+        var chained = await (await (await (await creation.Manager.DisableAsync(creation.Id))
+            .EnableAsync(creation.Id))
+            .PauseAsync(creation.Id))
+            .ResumeAsync(creation.Id);
+
+        await chained.RunNowAsync(creation.Id);
+        await chained.DeleteAsync(creation.Id);
+    }
+}


### PR DESCRIPTION
## Summary
- make IScheduledJobsManager mutating operations return the manager for fluent chaining
- return manager instance from ScheduledJobsManager methods and expose created IDs
- add unit test demonstrating chaining usage

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f07e8c9f48321a4a78aaa351fe053