### PR TITLE
Support deleting jobs and clean up state

### DIFF
--- a/samples/Components.Sample/Controllers/JobsController.cs
+++ b/samples/Components.Sample/Controllers/JobsController.cs
@@ -28,7 +28,8 @@ namespace Cloudbrick.JobApi.Controllers
             foreach (var id in ids)
             {
                 var st = await mgr.GetJobStateAsync(id);
-                list.Add(ApiModelMapper.ToSummary(st));
+                if (st != null)
+                    list.Add(ApiModelMapper.ToSummary(st));
             }
             return Ok(list);
         }

--- a/samples/Orleans.Jobs.Playground/Program.cs
+++ b/samples/Orleans.Jobs.Playground/Program.cs
@@ -67,6 +67,11 @@ class Program
             while (true)
             {
                 var state = await jobs.GetJobStateAsync(jobId);
+                if (state == null)
+                {
+                    Console.WriteLine("Job not found");
+                    break;
+                }
                 if (state.Status is JobStatus.Succeeded
                     or JobStatus.Failed
                     or JobStatus.Cancelled)
@@ -126,6 +131,11 @@ class Program
             while (true)
             {
                 var state = await jobs.GetJobStateAsync(jobId);
+                if (state == null)
+                {
+                    Console.WriteLine("Job not found");
+                    break;
+                }
                 if (state.Status is JobStatus.Succeeded
                     or JobStatus.Failed
                     or JobStatus.Cancelled)

--- a/src/Orleans.Jobs.Abstractions/Interfaces/IJobGrain.cs
+++ b/src/Orleans.Jobs.Abstractions/Interfaces/IJobGrain.cs
@@ -12,7 +12,8 @@ public interface IJobGrain : IGrainWithGuidKey
     Task PauseAsync();
     Task ResumeAsync();
     Task CancelAsync();
-    Task<JobState> GetStateAsync();
+    Task DeleteAsync();
+    Task<JobState?> GetStateAsync();
     Task FlushAsync();
     Task EmitTelemetryAsync(ExecutionEvent evt);
     Task SetTelemetryProviderAsync(string providerKey);

--- a/src/Orleans.Jobs.Abstractions/Interfaces/IJobsManagerGrain.cs
+++ b/src/Orleans.Jobs.Abstractions/Interfaces/IJobsManagerGrain.cs
@@ -14,6 +14,7 @@ public interface IJobsManagerGrain : IGrainWithStringKey
     Task PauseJobAsync(Guid jobId);
     Task ResumeJobAsync(Guid jobId);
     Task CancelJobAsync(Guid jobId);
-    Task<JobState> GetJobStateAsync(Guid jobId);
+    Task DeleteJobAsync(Guid jobId);
+    Task<JobState?> GetJobStateAsync(Guid jobId);
     Task<List<Guid>> ListJobsAsync();
 }

--- a/src/Orleans.Jobs.Grains/Grains/JobGrain.cs
+++ b/src/Orleans.Jobs.Grains/Grains/JobGrain.cs
@@ -443,7 +443,31 @@ internal class JobGrain : Grain, IJobGrain
         await TryFinalizeIfTerminalAsync();
     }
 
-    public Task<JobState> GetStateAsync() => Task.FromResult(_state.State);
+    public async Task DeleteAsync()
+    {
+        _schedulerCts?.Cancel();
+        _schedulerCts?.Dispose();
+        _schedulerCts = null;
+        _schedulerTimer?.Dispose();
+        _schedulerTimer = null;
+
+        foreach (var handle in _taskSubscriptions.Values)
+        {
+            try { await handle.UnsubscribeAsync(); } catch { /* ignore */ }
+        }
+        _taskSubscriptions.Clear();
+
+        await _state.ClearStateAsync();
+        _sink = null;
+        DeactivateOnIdle();
+    }
+
+    public Task<JobState?> GetStateAsync()
+    {
+        if (!_state.RecordExists || _state.State.JobId == Guid.Empty)
+            return Task.FromResult<JobState?>(null);
+        return Task.FromResult<JobState?>(_state.State);
+    }
 
     public Task FlushAsync() => _state.WriteWithRetry(_state.State.Clone());
 

--- a/src/Orleans.Jobs.Grains/Grains/JobsManagerGrain.cs
+++ b/src/Orleans.Jobs.Grains/Grains/JobsManagerGrain.cs
@@ -35,6 +35,15 @@ internal class JobsManagerGrain : Grain, IJobsManagerGrain
     public Task PauseJobAsync(Guid jobId) => GrainFactory.GetGrain<IJobGrain>(jobId).PauseAsync();
     public Task ResumeJobAsync(Guid jobId) => GrainFactory.GetGrain<IJobGrain>(jobId).ResumeAsync();
     public Task CancelJobAsync(Guid jobId) => GrainFactory.GetGrain<IJobGrain>(jobId).CancelAsync();
-    public Task<JobState> GetJobStateAsync(Guid jobId) => GrainFactory.GetGrain<IJobGrain>(jobId).GetStateAsync();
+    public async Task DeleteJobAsync(Guid jobId)
+    {
+        var job = GrainFactory.GetGrain<IJobGrain>(jobId);
+        if (_jobs.State != null && _jobs.State.Remove(jobId))
+        {
+            await _jobs.WriteStateAsync();
+        }
+        await job.DeleteAsync();
+    }
+    public Task<JobState?> GetJobStateAsync(Guid jobId) => GrainFactory.GetGrain<IJobGrain>(jobId).GetStateAsync();
     public Task<List<Guid>> ListJobsAsync() => Task.FromResult(_jobs.State ?? new List<Guid>());
 }

--- a/src/Orleans.Jobs.Grains/Managers/JobsManager.cs
+++ b/src/Orleans.Jobs.Grains/Managers/JobsManager.cs
@@ -23,7 +23,8 @@ namespace Cloudbrick.Orleans.Jobs.Managers
             foreach (var id in ids)
             {
                 var st = await mgr.GetJobStateAsync(id);
-                list.Add(ApiModelMapper.ToSummary(st));
+                if (st != null)
+                    list.Add(ApiModelMapper.ToSummary(st));
             }
             return list;
         }

--- a/src/Orleans.Jobs.Grains/Scheduled/ScheduledJobGrain.cs
+++ b/src/Orleans.Jobs.Grains/Scheduled/ScheduledJobGrain.cs
@@ -188,7 +188,7 @@ namespace Cloudbrick.Orleans.Jobs.Scheduled
                 {
                     var mgr = GrainFactory.GetGrain<IJobsManagerGrain>("manager");
                     var last = await mgr.GetJobStateAsync(_state.State.LastJobId.Value);
-                    if (last.Status is not JobStatus.Succeeded
+                    if (last != null && last.Status is not JobStatus.Succeeded
                         and not JobStatus.Failed
                         and not JobStatus.Cancelled)
                     {

--- a/tests/Orleans.Jobs.Tests/CancelTests.cs
+++ b/tests/Orleans.Jobs.Tests/CancelTests.cs
@@ -30,6 +30,7 @@ public class CancelTests : IClassFixture<ClusterFixture>
         await mgr.CancelJobAsync(jobId);
 
         var state = await mgr.GetJobStateAsync(jobId);
-        state.Status.Should().BeOneOf(Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Cancelling, Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Cancelled);
+        state.Should().NotBeNull();
+        state!.Status.Should().BeOneOf(Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Cancelling, Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Cancelled);
     }
 }

--- a/tests/Orleans.Jobs.Tests/DeleteTests.cs
+++ b/tests/Orleans.Jobs.Tests/DeleteTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Xunit;
+using Cloudbrick.Orleans.Jobs.Abstractions.Interfaces;
+using Cloudbrick.Orleans.Jobs.Abstractions.Models;
+
+namespace Orleans.Jobs.Tests;
+
+public class DeleteTests : IClassFixture<ClusterFixture>
+{
+    private readonly ClusterFixture _fx;
+    public DeleteTests(ClusterFixture fx) { _fx = fx; }
+
+    [Fact]
+    public async Task DeletedJobNotListedOrRetrievable()
+    {
+        var mgr = _fx.Cluster.GrainFactory.GetGrain<IJobsManagerGrain>("manager");
+        var spec = new JobSpec
+        {
+            Name = "delete-job",
+            MaxDegreeOfParallelism = 1,
+            FailFast = true
+        };
+        spec.Tasks["t1"] = new TaskSpec { ExecutorType = "delay", CommandJson = "{ \"milliseconds\": 10, \"steps\": 1 }" };
+
+        var jobId = await mgr.CreateJobAsync(spec);
+        await mgr.StartJobAsync(jobId);
+        await mgr.DeleteJobAsync(jobId);
+
+        var list = await mgr.ListJobsAsync();
+        list.Should().NotContain(jobId);
+
+        var state = await mgr.GetJobStateAsync(jobId);
+        state.Should().BeNull();
+    }
+}

--- a/tests/Orleans.Jobs.Tests/JobDagTests.cs
+++ b/tests/Orleans.Jobs.Tests/JobDagTests.cs
@@ -31,17 +31,18 @@ public class JobDagTests : IClassFixture<ClusterFixture>
         var jobId = await mgr.CreateJobAsync(spec);
         await mgr.StartJobAsync(jobId);
 
-        JobState state;
+        JobState? state;
         int guard = 0;
         do
         {
             await Task.Delay(100);
             state = await mgr.GetJobStateAsync(jobId);
+            state.Should().NotBeNull();
             guard++;
             if (guard > 200) break;
-        } while (state.Status != Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Succeeded &&
+        } while (state!.Status != Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Succeeded &&
                  state.Status != Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Failed);
 
-        state.Status.Should().Be(Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Succeeded);
+        state!.Status.Should().Be(Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Succeeded);
     }
 }

--- a/tests/Orleans.Jobs.Tests/PauseResumeTests.cs
+++ b/tests/Orleans.Jobs.Tests/PauseResumeTests.cs
@@ -36,24 +36,27 @@ public class PauseResumeTests : IClassFixture<ClusterFixture>
         await job.PauseAsync();
 
         var before = await job.GetStateAsync();
+        before.Should().NotBeNull();
         await Task.Delay(300);
         var after = await job.GetStateAsync();
+        after.Should().NotBeNull();
         // Progress should not decrease; may remain same due to pause
-        after.Tasks["t1"].Progress.Should().BeGreaterThanOrEqualTo(before.Tasks["t1"].Progress);
+        after!.Tasks["t1"].Progress.Should().BeGreaterThanOrEqualTo(before!.Tasks["t1"].Progress);
 
         await job.ResumeAsync();
 
         // wait for completion
-        JobState state;
+        JobState? state;
         int guard = 0;
         do
         {
             await Task.Delay(100);
             state = await job.GetStateAsync();
+            state.Should().NotBeNull();
             guard++;
             if (guard > 200) break;
-        } while (state.Status != JobStatus.Succeeded);
+        } while (state!.Status != JobStatus.Succeeded);
 
-        state.Status.Should().Be(JobStatus.Succeeded);
+        state!.Status.Should().Be(JobStatus.Succeeded);
     }
 }

--- a/tests/Orleans.Jobs.Tests/RetryTests.cs
+++ b/tests/Orleans.Jobs.Tests/RetryTests.cs
@@ -31,17 +31,18 @@ public class RetryTests : IClassFixture<ClusterFixture>
         var jobId = await mgr.CreateJobAsync(spec);
         await mgr.StartJobAsync(jobId);
 
-        JobState state;
+        JobState? state;
         int guard = 0;
         do
         {
             await Task.Delay(50);
             state = await mgr.GetJobStateAsync(jobId);
+            state.Should().NotBeNull();
             guard++;
             if (guard > 200) break;
-        } while (state.Status != Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Succeeded);
+        } while (state!.Status != Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Succeeded);
 
-        state.Tasks["t1"].Attempts.Should().BeGreaterThan(0);
+        state!.Tasks["t1"].Attempts.Should().BeGreaterThan(0);
         state.Status.Should().Be(Cloudbrick.Orleans.Jobs.Abstractions.Enums.JobStatus.Succeeded);
     }
 }


### PR DESCRIPTION
## Summary
- add DeleteJobAsync/DeleteAsync APIs and nullable state retrieval
- ensure jobs and schedulers handle deleted job IDs gracefully
- add tests verifying deleted jobs vanish from lists and cannot be retrieved

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f07eba8cc8321a9b09b4759fbc452